### PR TITLE
fix: improve GitHub Pages 404 handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: npx vite build --base /human-blueprint/
+      - run: npx vite build
+        env:
+          GITHUB_PAGES: "true"
 
       - name: Prepare GitHub Pages files
         run: |

--- a/docs/GITHUB_PAGES.md
+++ b/docs/GITHUB_PAGES.md
@@ -45,3 +45,13 @@ To trigger a deploy without pushing:
 
 1. Go to **Actions** → **Deploy to GitHub Pages**
 2. Click **Run workflow** → **Run workflow**
+
+## 6. Local Build Test
+
+To test the GitHub Pages build locally:
+
+```bash
+pnpm run build:pages
+```
+
+Then run `pnpm preview` and visit `http://localhost:4173/human-blueprint/` to verify.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build:pages": "GITHUB_PAGES=true vite build",
     "start": "NODE_ENV=production node dist/index.js",
     "preview": "vite preview --host",
     "check": "tsc --noEmit",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -152,7 +152,11 @@ function vitePluginManusDebugCollector(): Plugin {
 
 const plugins = [react(), tailwindcss(), jsxLocPlugin(), vitePluginManusDebugCollector()];
 
+// GitHub Pages project site: https://username.github.io/repo-name/
+const GITHUB_PAGES_BASE = "/human-blueprint/";
+
 export default defineConfig({
+  base: process.env.GITHUB_PAGES === "true" ? GITHUB_PAGES_BASE : "/",
   plugins,
   resolve: {
     alias: {


### PR DESCRIPTION
- Add base path to vite.config.ts via GITHUB_PAGES env (config as source of truth)
- Use GITHUB_PAGES=true in deploy workflow instead of CLI --base flag
- Add build:pages script for local testing of Pages build
- Update docs with local build test instructions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small configuration-only change affecting asset/link base paths in the GitHub Pages build; main risk is broken routing/asset URLs if the base flag is misapplied.
> 
> **Overview**
> GitHub Pages builds now derive the Vite `base` path from `process.env.GITHUB_PAGES`, using `/human-blueprint/` when enabled, instead of passing `--base` on the CLI.
> 
> The deploy workflow sets `GITHUB_PAGES=true` for the build step, `package.json` adds a `build:pages` script for local parity, and the GitHub Pages docs are updated with local verification steps (via `pnpm preview`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e35b290f88953b592f82f9af5cdb88790106f05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->