### PR TITLE
fix(ci): remove pnpm version from workflow to use packageManager from…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
         uses: actions/configure-pages@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
… package.json

Resolves ERR_PNPM_BAD_PM_VERSION: avoid specifying version in both the action config and package.json packageManager field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that alters tool version resolution in CI; minimal runtime risk beyond potential build differences if the `packageManager` value is misconfigured.
> 
> **Overview**
> The GitHub Pages deploy workflow no longer pins a `pnpm` version via `pnpm/action-setup`, allowing the version from `package.json`’s `packageManager` field to take precedence and avoiding `ERR_PNPM_BAD_PM_VERSION` conflicts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ac1df90508a552a700f94ad04e51dac3aa6690. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->